### PR TITLE
fix: EventMap.TryRemoveEvent should remove key

### DIFF
--- a/Solution/DungeonCrawler/DungeonEventMap/DungeonEventMap.cs
+++ b/Solution/DungeonCrawler/DungeonEventMap/DungeonEventMap.cs
@@ -32,6 +32,10 @@ public class EventMap() : IEquatable<EventMap>
         {
             removed = eventsAtPosition[ix];
             eventsAtPosition.RemoveAt(ix);
+            if (eventsAtPosition.Count == 0)
+            {
+                Events.Remove(position);
+            }
             return true;
         }
         removed = default;

--- a/Solution/Tests/DungeonCrawler/DungeonEventMap_should.cs
+++ b/Solution/Tests/DungeonCrawler/DungeonEventMap_should.cs
@@ -47,6 +47,15 @@ public class DungeonEventMap_should
     }
 
     [Fact]
+    public void not_have_key_when_last_event_is_removed_from_position()
+    {
+        EventMap map = new();
+        map.AddEvent(new Position(0, 0), new TileEvent(EventTrigger.OnEnter, "scriptName"));
+        map.TryRemoveEvent(new Position(0, 0), 0, out _);
+        map.Events.Keys.Count.ShouldBe(0);
+    }
+
+    [Fact]
     public void provide_view_of_events()
     {
         EventMap map = new();


### PR DESCRIPTION
when no events are left at specified position.

Fixes and closes #60 